### PR TITLE
Fix kvmfr build on kernel 6.10

### DIFF
--- a/app-emulation/looking-glass/files/kvmfr-kernel-6.10.patch
+++ b/app-emulation/looking-glass/files/kvmfr-kernel-6.10.patch
@@ -1,0 +1,12 @@
+diff --git a/module/kvmfr.c b/module/kvmfr.c
+index b5acd18..c99a5d7 100644
+--- a/module/kvmfr.c
++++ b/module/kvmfr.c
+@@ -30,6 +30,7 @@
+ #include <linux/highmem.h>
+ #include <linux/memremap.h>
+ #include <linux/version.h>
++#include <linux/vmalloc.h>
+ 
+ #include <asm/io.h>
+ 

--- a/app-emulation/looking-glass/looking-glass-7b_rc1.ebuild
+++ b/app-emulation/looking-glass/looking-glass-7b_rc1.ebuild
@@ -52,6 +52,10 @@ BDEPEND="virtual/pkgconfig
 
 CONFIG_CHECK="~UIO"
 
+PATCHES=(
+	"${FILESDIR}/kvmfr-kernel-6.10.patch"
+)
+
 src_unpack() {
 	einfo "Unpacking ${P}.tar.gz ..."
 	tar -xzf "${DISTDIR}/${P}.tar.gz" "${PN}-${MY_PV}" \


### PR DESCRIPTION
Quick patch to fix kvmfr build on kernel 6.10. 
The same fix can be found in the looking glass git repo. 